### PR TITLE
fix: enforce RAII for file I/O by removing explicit close() calls

### DIFF
--- a/assets/docs/roadmap.md
+++ b/assets/docs/roadmap.md
@@ -11,6 +11,7 @@
   - **UIService** for centralized presentation logic
   - **ConfigService** for isolated file I/O
   - Feature modules with clear responsibilities
+  - RAII for improved exception safety and reduced memory leaks
 
 - 🔄 **In Progress:** 
   - Implemetation of Arch. diagrams and docs 

--- a/src/core/config_service.cpp
+++ b/src/core/config_service.cpp
@@ -39,7 +39,6 @@ Config ConfigService::loadConfig() {
         }
     }
 
-    file.close();
     return config;
 }
 
@@ -56,8 +55,6 @@ void ConfigService::saveConfig() {
          << "show_banner=" << getValue("user_interface.show_banner", "true") << "\n\n"
          << "[behavior]\n"
          << "auto_apply_theme=" << getValue("behavior.auto_apply_theme", "true") << "\n";
-    
-    file.close();
 }
 
 std::string ConfigService::getValue(const std::string& key, const std::string& defaultValue) {

--- a/src/features/history.cpp
+++ b/src/features/history.cpp
@@ -16,7 +16,6 @@ void history::load() {
     while(std::getline(infile, line)) {
         cmdEntries.push_back(line);
     }
-    infile.close();
 }
 
 void history::save() {
@@ -24,7 +23,6 @@ void history::save() {
     for(auto& e : cmdEntries) { //for each loop
         outfile << e << "\n";
     }
-    outfile.close();
 }
 
 history::history(){

--- a/src/features/shortcuts.cpp
+++ b/src/features/shortcuts.cpp
@@ -63,7 +63,6 @@ void shortcuts::save(){
     for(auto& p : shortMap) { //for each loop
         outfile << p.first << "=" << p.second << "\n";
     }
-    outfile.close(); //close file
 }
 
 void shortcuts::list(){
@@ -88,7 +87,6 @@ void shortcuts::load() {
             shortMap[key] = value;
         }
     }
-    infile.close();
 }
 
 // Constructor: load shortcuts from file


### PR DESCRIPTION

This PR cleans up file handling by removing unnecessary explicit `.close()` calls from C++ stream usage and relying on RAII destructors for automatic resource cleanup.

### What Changed
- shortcuts.cpp
  - Removed `outfile.close()` from `shortcuts::save()`
  - Removed `infile.close()` from `shortcuts::load()`

- history.cpp
  - Removed `infile.close()` from `history::load()`
  - Removed `outfile.close()` from `history::save()`

- config_service.cpp
  - Removed `file.close()` from `ConfigService::loadConfig()`
  - Removed `file.close()` from `ConfigService::saveConfig()`

### Why
- Explicit `.close()` is redundant when using `std::ifstream` / `std::ofstream`
- RAII ensures streams are closed automatically when they go out of scope
- This reduces maintenance overhead and improves exception safety

Fixes #12 